### PR TITLE
fix: replace lookbehind in regex for older versions of Safari

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,8 +85,9 @@ function processCls(cls: string, map: Map<string, string>): void {
     const match = reg.exec(cls)
     if (match) {
       variantsPrefix = match[0]
-        .split(/(?<=:)(?:\b|$)/) // split at `:`
+        .split(":")
         .filter(Boolean)
+        .map((variant) => variant + ":")
         .sort()
         .join('')
       cls = cls.slice(variantsPrefix.length)


### PR DESCRIPTION
Removed the use of /(?<=:)/ (lookbehind in regex), as this construct causes errors in older versions of iOS (16.3 and below) and MacOS (16.3 and below). The code has been rewritten to use native split and restored separators.